### PR TITLE
Update README on learn-co-curriculum batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,26 @@ Through their journey, a Pokemon trainer can only have 6 Pokemon on their team.
 As you build, the eventual goal of a fully functional Pokemon team
 organizer where we can add and remove Pokemon as needed:
 
-![Showing Finished Project Example](/pokemon-teams-frontend/assets/pokemon_teams.gif)
+![completed example](https://curriculum-content.s3.amazonaws.com/module-3/pokemon_teams_completed.gif)
 
 Although we have not explicitly gone over some of the CRUD actions involved in
 adding and deleting relationships in this section of content, refer back to what
-you learned about CRUD actions in Rails and use your new understanding of 
+you learned about CRUD actions in Rails and use your new understanding of
 rendering JSON to try and solve these challenges.
 
 ## Goals
 
-**Note:** There are no tests in this lesson so running the `learn` command will not work. Rather, your 
-task is to build towards the goals below by constructing both a Rails API and JavaScript frontend together. 
-The specific implementation for achieving these goals is left to you.
+**Note:** There are no tests in this lesson so running the `learn` command will
+not work. Rather, your task is to build towards the goals below by constructing
+both a Rails API and JavaScript frontend together. The specific implementation
+for achieving these goals is left to you.
 
-- When a user loads the page, they should see all trainers, with their current team of Pokemon.
-- Whenever a user hits Add Pokemon and they have space on their team, they should get a new Pokemon.
-- Whenever a user hits Release Pokemon on a specific Pokemon team, that specific Pokemon should be 
-released from the team.
+- When a user loads the page, they should see all trainers, with their current
+  team of Pokemon.
+- Whenever a user hits "Add Pokemon" and they have space on their team, they
+  should get a new Pokemon.
+- Whenever a user hits "Release Pokemon" on a specific Pokemon team, that
+  specific Pokemon should be released from the team.
 
 ## Backend
 
@@ -59,18 +62,33 @@ gem 'faker'
 
 While we are in the Gemfile, uncomment `gem 'rack-cors'`, then run 
 `bundle install`. If you recall, `rack-cors` is necessary for cross-origin
-resource sharing. To get rack-cors working, once the gem is installed, add the
-following to `config/application.rb` inside `class Application <
-Rails::Application` without replacing any other content:
+resource sharing. To get rack-cors working, once the gem is installed, uncomment
+the following code in `config/initializers/cors.rb`:
 
 ```rb
-config.middleware.insert_before 0, Rack::Cors do
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins '*'
-    resource '*', headers: :any, methods: [:get, :post, :delete]
+    origins "*"
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end
 end
 ```
+
+> **Aside**: Notice that we've put this in `config/initializers/cors.rb`. We've
+also seen this code being placed in `config/application.rb`. Both will work, but
+Rails provides the `cors.rb` file specifically for defining our rules for
+cross-origin HTTP requests.
+
+The string after `origins` specifies which hosts will be allowed to make
+requests to your API. Your brand-new rails app probably comes with the string
+`"example.com"` there — change it to "*" to allow all hosts. In a production
+application, you might want to specify a particular hostname.
+
+If you already have a rails server running, stop and restart it so that your
+configuration changes can take effect.
 
 With these gems installed, use the following resource generators to create
 resources for this API:
@@ -80,9 +98,10 @@ rails g resource trainer name
 rails g resource pokemon species nickname trainer:references
 ```
 
-Run `rails db:migrate` to create a schema, models, and controllers. Using
+Run `rails db:migrate` to execute our migration files, and create database and schema. Using
 `trainer:references` will set up `belongs_to :trainer` in the `Pokemon` model,
-though it won't update the `Trainer` side of the relationship.
+though it won't update the other side of the relationship. You will need to add
+the `has_many :pokemons` in the `Trainer` model yourself.
 
 In `db/seeds.rb`, add the following and run `rails db:seed`:
 
@@ -94,14 +113,15 @@ Trainer.delete_all
 Pokemon.delete_all
 
 trainers_name = [
+  'Natalie',
   'Prince',
   'Dick',
+  'Rachel',
   'Garry',
   'Jason',
   'Matt',
-  'Noah',
-  'Adam',
-  'Arthur'
+  'Niky',
+  'Ashley'
 ]
 
 trainer_collection = []
@@ -129,9 +149,32 @@ have populated your tables with seed data.
 Some basic structure is provided in the folder `pokemon-teams-frontend`, including
 an HTML, CSS and JS file set up to work together.
 
+## Running the Server
+
+The API server should be started by accessing the folder pokemon-teams-backend (`cd pokemon-teams-backend`) and running `rails s` from a terminal window. It should run on port :3000 since the `pokemon-teams-frontend/src/index.js` file has a constant `BASE_URL` setup to use that port.
+
+If for any reason you had to quit the running server and have to restart it, you might see an error saying **port 3000 already in use**. In this case, do the following:
+
+Run `lsof -i :3000` to inspect what's running on port 3000 (alternatively, you can try `ps aux | grep 3000`).
+You will see something like the following:
+```
+COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME 
+ruby 9639 matteo 28u IPv4 0x89939df84558ba7 0t0 TCP localhost:hbci (LISTEN) 
+ruby 9639 matteo 29u IPv6 0x89939dfa2ef1897 0t0 TCP localhost:hbci (LISTEN)
+```
+
+Kill the process running by doing `kill -9 <PID_HERE>`, so in the case of my example `kill -9 9639`.
+Now the `rails s` command should start the server on port 3000 without issues.
+
+> **Aside**: In general, you can always specify what port to use when running the server, by running: `rails s -p PORT_NUMBER` (eg: `rails s -p 3001`).
+
+The frontend should be started by accessing the folder pokemon-teams-frontend (`cd pokemon-teams-frontend`) and, in a new terminal window, run `open index.html` or simply right-click on the file name and select `open in browser` if this option is available.
+
+**Keep the rails server running since our frontend will fire requests to our backend API in order to retrieve the existing Trainers and Pokemons, as well as performing other actions like creating and deleting Pokemons.**
+
 ### Suggested HTML
 
-As CSS is already provided, you can use this example HTML as a guide when
+As CSS is already provided, you can use this sample HTML as a guide when
 building out your frontend JavaScript:
 
 ```html
@@ -147,10 +190,26 @@ building out your frontend JavaScript:
 </div>
 ```
 
+### Building out the rest of the project
+
+Remember that your user stories are:
+
+- When a user loads the page, they should see all trainers, with their current
+  team of Pokemon.
+- Whenever a user hits "Add Pokemon" and they have space on their team, they
+  should get a new Pokemon.
+- Whenever a user hits "Release Pokemon" on a specific Pokemon team, that
+  specific Pokemon should be released from the team.
+
+You should build out just enough of your Rails API to achieve the above. You
+_should not_ build out full CRUD on each model. For example, the frontend will
+not have the ability to create a new Trainer, so your backend should not have a
+`POST /trainers` route.
+
 ## Example API Requests
 
 To help you shape your data, here are some JSON data structures you should look
-to mirror while building out your applications:
+to mirror while building out your backend:
 
 ### Getting All Trainers and their Pokemon
 
@@ -184,6 +243,10 @@ GET /trainers
 ```
 
 ### Adding a Pokemon
+
+* Note: When adding a new pokemon, the nickname should be generated using the
+  `Faker::Name` gem and the species should be generated using the
+  `Faker::Games::Pokemon` gem. See the seeds.rb file above as an example.
 
 ```text
 #=> Example Request

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Through their journey, a Pokemon trainer can only have 6 Pokemon on their team.
 As you build, the eventual goal of a fully functional Pokemon team
 organizer where we can add and remove Pokemon as needed:
 
-![completed example](https://curriculum-content.s3.amazonaws.com/module-3/pokemon_teams_completed.gif)
+![Showing Finished Project Example](/pokemon-teams-frontend/assets/pokemon_teams.gif)
 
 Although we have not explicitly gone over some of the CRUD actions involved in
 adding and deleting relationships in this section of content, refer back to what


### PR DESCRIPTION
Updated the README using the version containing server instructions from the `software engineering testing batch` and replaced instructions regarding what `rake db:migrate` does.